### PR TITLE
Issue #28 feat(Database): Configure Liquibase for User API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/com/fawry/user_api/config/DBConfig.java
+++ b/src/main/java/com/fawry/user_api/config/DBConfig.java
@@ -4,13 +4,10 @@ import com.fawry.user_api.config.properties.DatasourceProperties;
 import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
-import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
 
 import javax.sql.DataSource;
-import java.util.Properties;
+
 
 @Configuration
 public class DBConfig {
@@ -25,13 +22,13 @@ public class DBConfig {
     public DataSource dataSource() {
         var dataSource = new HikariDataSource();
 
-       dataSource.setDriverClassName(properties.getDriver());
-       dataSource.setJdbcUrl(properties.getUrl());
-       dataSource.setUsername(properties.getUsername());
-       dataSource.setPassword(properties.getPassword());
-       dataSource.setMaximumPoolSize(properties.getMaxPoolSize());
-       dataSource.setMaxLifetime(properties.getMaxLifeTime());
-       return dataSource;
+        dataSource.setDriverClassName(properties.getDriver());
+        dataSource.setJdbcUrl(properties.getUrl());
+        dataSource.setUsername(properties.getUsername());
+        dataSource.setPassword(properties.getPassword());
+        dataSource.setMaximumPoolSize(properties.getMaxPoolSize());
+        dataSource.setMaxLifetime(properties.getMaxLifeTime());
+        return dataSource;
     }
 
 }

--- a/src/main/java/com/fawry/user_api/config/properties/DatasourceProperties.java
+++ b/src/main/java/com/fawry/user_api/config/properties/DatasourceProperties.java
@@ -17,5 +17,52 @@ public class DatasourceProperties {
     private int maxPoolSize;
     private int maxLifeTime;
 
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getMaxLifeTime() {
+        return maxLifeTime;
+    }
+
+    public void setMaxLifeTime(int maxLifeTime) {
+        this.maxLifeTime = maxLifeTime;
+    }
 }
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -15,7 +15,7 @@ spring:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://localhost:8765/eureka
+      defaultZone: http://localhost:8761/eureka
 custom:
   datasource:
     driver: org.postgresql.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 spring:
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog/db.changelog-master.xml
   profiles:
-    active: dev
+    active: test
   application:
        name: User-Api

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,49 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="create_enum_user_role" author="muhammad hussein" context="development">
+
+        <sql>
+            CREATE TYPE user_role AS ENUM ('ADMIN', 'CUSTOMER')
+        </sql>
+    </changeSet>
+
+    <changeSet id="create_users_tbl" author="muhammad hussein" context="development">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="users"/>
+            </not>
+        </preConditions>
+        <createTable tableName="users" schemaName="public">
+            <column name="user_id" type="SERIAL" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="email" type="VARCHAR(255)">
+                <constraints unique="true" nullable="false"/>
+            </column>
+            <column name="password" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="user_role">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+
+    <changeSet id="idx_users_email" author="muhammad hussein" context="development">
+        <sqlFile path="db/changelog/sql/idx_users_email_v.0.0.0.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/idx_users_email_v.0.0.0.sql
+++ b/src/main/resources/db/changelog/sql/idx_users_email_v.0.0.0.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_email ON users(email);


### PR DESCRIPTION
Closed #28

This PR introduces Liquibase changesets to manage the database schema for the users table and user_role enum. The changes include:

Create user_role Enum:

Added a new enum type user_role with values ADMIN and CUSTOMER.

Create users Table:

Created the users table with the following columns:

user_id: Primary key (auto-incrementing).

email: Unique and not nullable.

password: Not nullable.

role: Uses the user_role enum and is not nullable.

is_active: Boolean with a default value of true.

created_at and updated_at: Timestamps with time zones, defaulting to the current timestamp.

Add Index on email Column:

Added an index on the email column to improve query performance.