### PR TITLE
Issue #6 feat(Database): Configure Liquibase for User API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,11 @@
 spring:
+  datasource:
+    driver: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/user_db
+    username: postgres
+    password: 12345
+    maxPoolSize: 20
+    maxLifeTime: 1800000
   config:
     activate:
       on-profile: test
@@ -15,15 +22,9 @@ spring:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://localhost:8765/eureka
-custom:
-  datasource:
-    driver: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/user_db
-    username: postgres
-    password: 12345
-    maxPoolSize: 20
-    maxLifeTime: 1800000
+      defaultZone: http://localhost:8761/eureka
+
+
 
 server:
   port: 1100

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 spring:
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog/db.changelog-master.xml
   profiles:
-    active: dev
+    active: test
   application:
        name: User-Api

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,50 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!-- Create user_role enum -->
+    <changeSet id="create_enum_user_role" author="muhammad hussein" context="development">
+        <sql>
+            CREATE TYPE user_role AS ENUM ('ADMIN', 'CUSTOMER');
+        </sql>
+    </changeSet>
+
+    <!-- Create users table -->
+    <changeSet id="create_users_tbl" author="muhammad hussein" context="development">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="users"/>
+            </not>
+        </preConditions>
+        <createTable tableName="users" schemaName="public">
+            <column name="user_id" type="SERIAL" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="email" type="VARCHAR(255)">
+                <constraints unique="true" nullable="false"/>
+            </column>
+            <column name="password" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="user_role">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <!-- Add index on email column -->
+    <changeSet id="idx_users_email" author="muhammad hussein" context="development">
+        <sqlFile path="db/changelog/sql/idx_users_email_v.0.0.0.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/idx_users_email_v.0.0.0.sql
+++ b/src/main/resources/db/changelog/sql/idx_users_email_v.0.0.0.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_email ON users(email);


### PR DESCRIPTION
Close #6 
This PR introduces Liquibase changesets to manage the database schema for the users table and user_role enum. The changes include:

Create user_role Enum:

Added a new enum type user_role with values ADMIN and CUSTOMER.

Create users Table:

Created the users table with the following columns:

user_id: Primary key (auto-incrementing).

email: Unique and not nullable.

password: Not nullable.

role: Uses the user_role enum and is not nullable.

is_active: Boolean with a default value of true.

created_at and updated_at: Timestamps with time zones, defaulting to the current timestamp.

Add Index on email Column:

Added an index on the email column to improve query performance.